### PR TITLE
UGC API support

### DIFF
--- a/src/kSamsok.php
+++ b/src/kSamsok.php
@@ -35,6 +35,20 @@ class kSamsok {
     }
   }
 
+  protected function validJson($url) {
+    try {
+      @$json = file_get_contents($url);
+
+      if ($json === false || json_decode($json) === null) {
+        throw new Exception('Bad API request. (' . $url . ')');
+      }
+    } catch(Exception $e) {
+      echo 'Caught Exception: ',  $e->getMessage(), "\n";
+      // these are fatal errors so kill the script
+      die();
+    }
+  }
+
   protected function prepareUrl($url) {
     // replace withe space
     $url = preg_replace('/\\s/', '%20', $url);
@@ -326,5 +340,16 @@ class kSamsok {
     } else {
       return false;
     }
+  }
+
+  public function ugcObject($objectId) {
+    $objectId = $this->idFormat($objectId, 'url');
+
+    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&scope=all&objectUri=' . $objectId . '&format=json'
+    $this->validJson($urlQuery);
+
+    $json = file_get_contents($urlQuery);
+
+    return json_decode($json);
   }
 }

--- a/src/kSamsok.php
+++ b/src/kSamsok.php
@@ -141,7 +141,7 @@ class kSamsok {
   }
 
   protected function idFormat($id, $format = 'raw') {
-    // $format can be string 'xml' or string 'raw'
+    // $format can be string 'xml'/string 'raw'/string 'uri'
 
     // if is the entire url strip it off
     if (stripos($id, 'http://kulturarvsdata.se/') !== false) {
@@ -175,6 +175,14 @@ class kSamsok {
         // if no format exists add '/xml/'
         $formatLocation = strrpos($id, '/', 0);
         return substr_replace($id, '/xml', $formatLocation, 0);
+      }
+    }
+
+    if ($format === 'url') {
+      if (strpos($id,'http://kulturarvsdata.se/')) {
+        return $id;
+      } else {
+        return 'http://kulturarvsdata.se/' . $id;
       }
     }
   }

--- a/src/kSamsok.php
+++ b/src/kSamsok.php
@@ -357,8 +357,6 @@ class kSamsok {
     $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&scope=count&objectUri=' . $objectId . '&format=json';
     $this->validJson($urlQuery);
 
-    ;
-
     return file_get_contents($urlQuery);
   }
 

--- a/src/kSamsok.php
+++ b/src/kSamsok.php
@@ -1,14 +1,22 @@
 <?php
 class kSamsok {
   public $key;
+  public $ugcKey;
   public $url = 'http://kulturarvsdata.se/ksamsok/api?';
+  public $ugcUrl = 'http://ugc.kulturarvsdata.se/UGC-hub/api?';
 
-  public function __construct($key) {
+  public function __construct($key, $ugcKey = false) {
     $this->key = $key;
+    $this->ugcKey = $ugcKey;
     // checks if API Key or request URL is bad(can also )
     // check if URL does return a error
     $testQuery = $this->url . 'x-api=' . $this->key . '&method=search&query=text%3D"test"&recordSchema=presentation';
     $this->validXml($testQuery);
+
+    if ($this->ugcKey !== false) {
+      $testQuery = $this->url . 'x-api=' . $this->ugcKey . 'method=retrieve&scope=count&objectUri=all';
+      $this->validXml($testQuery);
+    }
   }
 
   // Checks if valid xml is returned, if not throw Exception and kill the script

--- a/src/kSamsok.php
+++ b/src/kSamsok.php
@@ -345,7 +345,7 @@ class kSamsok {
   public function ugcObject($objectId) {
     $objectId = $this->idFormat($objectId, 'url');
 
-    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&scope=all&objectUri=' . $objectId . '&format=json';
+    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey . '&method=retrieve&scope=all&objectUri=' . $objectId . '&format=json';
     $this->validJson($urlQuery);
 
     return file_get_contents($urlQuery);
@@ -354,7 +354,7 @@ class kSamsok {
   public function ugcCount($objectId) {
     $objectId = $this->idFormat($objectId, 'url');
 
-    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&scope=count&objectUri=' . $objectId . '&format=json';
+    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey . '&method=retrieve&scope=count&objectUri=' . $objectId . '&format=json';
     $this->validJson($urlQuery);
 
     return file_get_contents($urlQuery);
@@ -362,9 +362,9 @@ class kSamsok {
 
   public function ugcSingleRelation($contentId) {
 
-    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&objectUri=all&contentId=' . $contentId . '&scope=single&format=json';
+    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey . '&method=retrieve&objectUri=all&contentId=' . $contentId . '&scope=single&format=json';
     $this->validJson($urlQuery);
 
     return file_get_contents($urlQuery);
-  } 
+  }
 }

--- a/src/kSamsok.php
+++ b/src/kSamsok.php
@@ -352,4 +352,15 @@ class kSamsok {
 
     return json_decode($json);
   }
+
+  public function ugcCount($objectId) {
+    $objectId = $this->idFormat($objectId, 'url');
+
+    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&scope=count&objectUri=' . $objectId . '&format=json'
+    $this->validJson($urlQuery);
+
+    $json = file_get_contents($urlQuery);
+
+    return json_decode($json);
+  } 
 }

--- a/src/kSamsok.php
+++ b/src/kSamsok.php
@@ -345,22 +345,28 @@ class kSamsok {
   public function ugcObject($objectId) {
     $objectId = $this->idFormat($objectId, 'url');
 
-    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&scope=all&objectUri=' . $objectId . '&format=json'
+    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&scope=all&objectUri=' . $objectId . '&format=json';
     $this->validJson($urlQuery);
 
-    $json = file_get_contents($urlQuery);
-
-    return json_decode($json);
+    return file_get_contents($urlQuery);
   }
 
   public function ugcCount($objectId) {
     $objectId = $this->idFormat($objectId, 'url');
 
-    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&scope=count&objectUri=' . $objectId . '&format=json'
+    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&scope=count&objectUri=' . $objectId . '&format=json';
     $this->validJson($urlQuery);
 
-    $json = file_get_contents($urlQuery);
+    ;
 
-    return json_decode($json);
+    return file_get_contents($urlQuery);
+  }
+
+  public function ugcSingleRelation($contentId) {
+
+    $urlQuery = $this->ugcUrl . 'x-api=' . $this->ugcKey '&method=retrieve&objectUri=all&contentId=' . $contentId . '&scope=single&format=json';
+    $this->validJson($urlQuery);
+
+    return file_get_contents($urlQuery);
   } 
 }


### PR DESCRIPTION
 - [x] uri to URL parsing support.
 - [x] `ugcObject('SOCH uri string')`
 - [x] `ugcCount('SOCH uri string')`
 - [x] `ugcSingleRelation('ugc id string')`
 - [ ] testing
 - [ ] update documentation

**Other Merge Blockers**

Currently the UGC API(`scope=count`) does not return expected results, the following requests return the same result:
 - `http://ugc.kulturarvsdata.se/UGC-hub/api?x-api=ex2147ap36&method=retrieve&scope=count&objectUri=http://kulturarvsdata.se/raa/fmi/10034401240001`
 - `http://ugc.kulturarvsdata.se/UGC-hub/api?x-api=ex2147ap36&method=retrieve&scope=count&objectUri=all`

Not known if there is a maximum number of results if so support for `maxCount` and `selectFrom` is needed.

**Other Notes**
`scope=single` requires `objectUri` 
`http://ugc.kulturarvsdata.se/UGC-hub/api?x-api=ex2147ap36&method=retrieve&contentId=2089464&scope=single`

Relations from Platsr is not included(nor a relation to Platsr):
 - http://ugc.kulturarvsdata.se/UGC-hub/api?x-api=ex2147ap36&method=retrieve&scope=all&objectUri=http://kulturarvsdata.se/raa/fmi/10034401240001
 - http://www.platsr.se/platsr/visa/plats/id/51000000058700